### PR TITLE
docs: add official-repository declaration to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 *Create, review, merge, and search GitHub from the agent, with a CI composite action, polling review bot, and status-check gate.*
 
+> **Official repository.** This is the only official repository of dsh-github, maintained by PerryLink. Same-name repositories under other accounts are not affiliated.
+
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![DSH plugin](https://img.shields.io/badge/dsh-plugin-✅-green)](https://github.com/topics/dsh-plugin)
 [![Node](https://img.shields.io/badge/node-%5E22.19%20%7C%7C%20%3E%3D24-brightgreen.svg)](#)

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,6 +6,8 @@
 
 *在 agent 中创建、审查、合并与搜索 GitHub，附带 CI 复合动作、轮询式审查机器人与状态检查门禁。*
 
+> **官方仓库。** 本仓库是 dsh-github 的唯一官方仓库，由 PerryLink 维护。其他账号下的同名仓库与本项目无关。
+
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![DSH plugin](https://img.shields.io/badge/dsh-plugin-✅-green)](https://github.com/topics/dsh-plugin)
 [![Node](https://img.shields.io/badge/node-%5E22.19%20%7C%7C%20%3E%3D24-brightgreen.svg)](#)


### PR DESCRIPTION
Adds the official-repository declaration (en/zh) for brand protection against same-name repositories. Same-name repos under other accounts are not affiliated.